### PR TITLE
Added --clean switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ThemeUtils/.idea/
 ThemeUtils/bin/
 ThemeUtils/obj/
+.suo
+.vs

--- a/ThemeUtils/Program.cs
+++ b/ThemeUtils/Program.cs
@@ -39,8 +39,9 @@ namespace nDriven.Telligent.ThemeUtils
                 Console.WriteLine("You must specify an output directory --outputDir=OUTPUT_DIRECTORY");
                 return;
             }
+            var clean = GetArgumentFlag(args, "clean");
 
-            var themeExtractor = new ThemeExtractor(themeFilePath, outputDirectory);
+            var themeExtractor = new ThemeExtractor(themeFilePath, outputDirectory, clean);
             try
             {
                 themeExtractor.Extract();

--- a/ThemeUtils/ThemeExtractor.cs
+++ b/ThemeUtils/ThemeExtractor.cs
@@ -16,7 +16,7 @@ namespace nDriven.Telligent.ThemeUtils
 
         public TextWriter Logger { get; }
 
-        public ThemeExtractor([NotNull] string themeFilePath, [NotNull] string outputDirectory, TextWriter logger = null)
+        public ThemeExtractor([NotNull] string themeFilePath, [NotNull] string outputDirectory, bool clean = false, TextWriter logger = null)
         {
             ThemeFilePath = themeFilePath.Trim();
             if (!File.Exists(ThemeFilePath))
@@ -25,11 +25,16 @@ namespace nDriven.Telligent.ThemeUtils
             }
 
             OutputDirectory = outputDirectory.Trim();
+            if (Directory.Exists(OutputDirectory) && clean)
+            {
+                Directory.Delete(OutputDirectory, true);
+            }
+
             if (!Directory.Exists(OutputDirectory))
             {
                 Directory.CreateDirectory(OutputDirectory);
             }
-
+            
             Logger = logger ?? Console.Out;
         }
 
@@ -148,6 +153,9 @@ namespace nDriven.Telligent.ThemeUtils
                     break;
                 case "javascript":
                     fileName += ".js";
+                    break;
+                case "unknown":
+                    fileName += ".txt";
                     break;
                 default:
                     fileName += $".{language}";

--- a/ThemeUtils/ThemeExtractor.cs
+++ b/ThemeUtils/ThemeExtractor.cs
@@ -154,11 +154,8 @@ namespace nDriven.Telligent.ThemeUtils
                 case "javascript":
                     fileName += ".js";
                     break;
-                case "unknown":
-                    fileName += ".txt";
-                    break;
                 default:
-                    fileName += $".{language}";
+                    fileName += ".txt";
                     break;
             }
 


### PR DESCRIPTION
Great work, this is great!

I've added a --clean switch to clear the folder before running. This is useful to ensure files removed from the theme don't hang around in an existing folder after an extract. I figure this could be more of an issue when the --package switch is implemented.

I also updated the switch statement in ExtractContentScript to force the file extension to be .txt as seemed to be the intent from the null coalesce statement parsing the language. Files with a language of 'unknown' in the theme file had a filename of *.unknown and not *.txt.